### PR TITLE
Feature CLI identifier generator

### DIFF
--- a/cli.php
+++ b/cli.php
@@ -4,6 +4,7 @@ namespace csrui\WPConstruct\Plugin;
 
 use csrui\WPConstruct\Plugin\Command\Fixture;
 use csrui\WPConstruct\Plugin\Command\Example;
+use csrui\WPConstruct\Plugin\Command\Generator;
 
 use WP_CLI;
 
@@ -16,4 +17,5 @@ if ( file_exists( dirname( __FILE__ ) . '/vendor/autoload.php' ) ) {
 }
 
 WP_CLI::add_command( 'fixtures', Fixture::class );
+WP_CLI::add_command( 'generator', Generator::class );
 WP_CLI::add_command( 'example', Example::class );

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -6,14 +6,24 @@ We want to add a few commands for WP CLI to aid with day to day work.
 
 * Version bumping when updating your plugin code
 * Generators
-    * Post Types
-    * Taxonomies
-    * Fields
-    * Fixtures
-    * Migrations
+  * Post Types
+  * Taxonomies
+  * Fields
+  * Fixtures
+  * Migrations
 
 For now you can start using the super useful
 
-```
+```bash
 wp banana
+```
+
+## Commands Available
+
+### Generator
+
+Generate a random identifier to use on ACF Groups and Fields.
+
+```bash
+wp generator acf_identifier
 ```

--- a/docs/content_types/README.md
+++ b/docs/content_types/README.md
@@ -161,7 +161,7 @@ class ClosingDays extends Group {
 ...
 ```
 
-Many fields configuration, copied from ACF export.
+Many fields configuration, copied from ACF export. 
 
 ```php
 ...					
@@ -208,4 +208,12 @@ Many fields configuration, copied from ACF export.
 	}
 }
 
+```
+
+**Here's a TIP:**
+
+If you'd like to just create these classes by hand you can use the handy [CLI](/cli) Generator to generate unique keys.
+
+```bash
+wp generator acf_identifier
 ```

--- a/lib/Command/Generator.php
+++ b/lib/Command/Generator.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace csrui\WPConstruct\Plugin\Command;
+
+use WP_CLI_Command;
+use WP_CLI;
+
+/**
+ * Generator
+ *
+ * @since      0.0.0
+ * @package    WPPlugin
+ * @author     Rui Sardinha <mail@ruisardinha.com>
+ */
+class Generator extends WP_CLI_Command {
+
+	public function gen_acf_id() {
+
+		echo substr( md5(), 0, 14 );
+	}
+}

--- a/lib/Command/Generator.php
+++ b/lib/Command/Generator.php
@@ -3,19 +3,23 @@
 namespace csrui\WPConstruct\Plugin\Command;
 
 use WP_CLI_Command;
-use WP_CLI;
 
 /**
  * Generator
  *
  * @since      0.0.0
- * @package    WPPlugin
+ * @package    csrui\WPConstruct\Plugin\Command
  * @author     Rui Sardinha <mail@ruisardinha.com>
  */
 class Generator extends WP_CLI_Command {
 
-	public function gen_acf_id() {
+	/**
+	 * Generate ACF Idenfitier
+	 *
+	 * @return void
+	 */
+	public function acf_identifier() {
 
-		echo substr( md5(), 0, 14 );
+		WP_CLI::log( 'Your key: ' . uniqid() );
 	}
 }


### PR DESCRIPTION
Useful when hand creating ACF fields / group classes and you need to generate a unique ID.