### PR TITLE
Fixes RestFieldsRegistry::sorter

### DIFF
--- a/lib/ContentType/RestFieldsRegistry.php
+++ b/lib/ContentType/RestFieldsRegistry.php
@@ -89,12 +89,12 @@ class RestFieldsRegistry {
 			$locations = $obj->get_locations();
 
 			foreach ( $locations as $location ) {
-                if ( ! isset($location['post_type'] ) ) {
-                    continue;
-                }
+				if ( ! isset( $location['post_type'] ) ) {
+					continue;
+				}
 
-                $data[ $location['post_type'] ][] = $obj;
-            }
+				$data[ $location['post_type'] ][] = $obj;
+			}
 		}
 
 		return $data;

--- a/lib/ContentType/RestFieldsRegistry.php
+++ b/lib/ContentType/RestFieldsRegistry.php
@@ -88,13 +88,13 @@ class RestFieldsRegistry {
 
 			$locations = $obj->get_locations();
 
-			foreach ( $locations as $type => $value ) {
-				if ( $type !== 'post_type' ) {
-					continue;
-				}
+			foreach ( $locations as $location ) {
+                if ( ! isset($location['post_type'] ) ) {
+                    continue;
+                }
 
-				$data[ $value ][] = $obj;
-			}
+                $data[ $location['post_type'] ][] = $obj;
+            }
 		}
 
 		return $data;


### PR DESCRIPTION
The update of the fields location format had broken the RestFieldsRegistry::sorter.